### PR TITLE
Fix: TS2345 Argument Type Exception After Deno 1.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const ngrok = await Ngrok.create({
 await ngrok.destroy()
 ```
 
-- Optionally provide an exit code: `await ngrok.destroy(9)`
+- Optionally provide an exit code: `await ngrok.destroy("SIGKILL")`
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ const ngrok = await Ngrok.create({
 await ngrok.destroy()
 ```
 
-- Optionally provide an exit code: `await ngrok.destroy("SIGKILL")`
-
 ### API
 
 See [generated documentation](https://doc.deno.land/https/deno.land/x/ngrok@3.1.1/mod.ts)

--- a/deps.ts
+++ b/deps.ts
@@ -2,6 +2,7 @@ export { join } from "https://deno.land/std@0.86.0/path/mod.ts"
 export { exists } from "https://deno.land/std@0.87.0/fs/mod.ts"
 export { readLines } from "https://deno.land/std@0.87.0/io/mod.ts"
 export { TypedCustomEvent, TypedEventTarget } from "https://deno.land/x/typed_event_target@1.0.1/mod.ts"
+export { satisfies as semverSatisfies } from "https://deno.land/x/semver@v1.4.0/mod.ts"
 
 // Testing
 export { serve } from "https://deno.land/std@0.88.0/http/server.ts"

--- a/mod.ts
+++ b/mod.ts
@@ -107,10 +107,10 @@ export class Ngrok extends TypedEventTarget<Events> {
         return new Ngrok(bin, args)
     }
 
-    destroy(code?: number): Promise<void> {
+    destroy(code?: Deno.Signal): Promise<void> {
         this.instance.stdout.close()
         this.instance.stderr.close()
-        this.instance.kill(code || 15)
+        this.instance.kill(code || "SIGTERM")
         this.instance.close()
 
         return new Promise(resolve => {

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { exists, join, readLines, TypedCustomEvent, TypedEventTarget } from "./deps.ts"
+import { exists, join, readLines, TypedCustomEvent, TypedEventTarget, semverSatisfies } from "./deps.ts"
 
 type Events = {
     status: Deno.ProcessStatus
@@ -107,10 +107,11 @@ export class Ngrok extends TypedEventTarget<Events> {
         return new Ngrok(bin, args)
     }
 
-    destroy(code?: Deno.Signal): Promise<void> {
+    destroy(): Promise<void> {
+        const signal: any = semverSatisfies(Deno.version.deno, ">=1.14.0") ? "SIGTERM" : 15;
         this.instance.stdout.close()
         this.instance.stderr.close()
-        this.instance.kill(code || "SIGTERM")
+        this.instance.kill(signal)
         this.instance.close()
 
         return new Promise(resolve => {


### PR DESCRIPTION
Since Deno change their `Deno.Signal` definition from `enum` to `string` type after v1.14.0, package will not work correctly and throw following exception:
```bash
error: TS2345 [ERROR]: Argument of type 'number' is not assignable to parameter of type 'Signal'.
        this.instance.kill(code || 15)
                           ~~~~~~~~~~
    at https://deno.land/x/ngrok@3.1.1/mod.ts:113:28
```

This patch will remove `destroy` function parameter, and using `semver@1.4.0` package compare `Deno.version.deno` provide downgrade support.

For additional information, please look at denoland/deno#11900